### PR TITLE
Use different names to convey thread status

### DIFF
--- a/ext/gvl_tracing_native_extension/gvl_tracing.c
+++ b/ext/gvl_tracing_native_extension/gvl_tracing.c
@@ -125,8 +125,8 @@ static void on_event(rb_event_flag_t event_id, const rb_internal_thread_event_da
   const char* event_name = "bug_unknown_event";
   switch (event_id) {
     case RUBY_INTERNAL_THREAD_EVENT_READY:     event_name = "ready";     break;
-    case RUBY_INTERNAL_THREAD_EVENT_RESUMED:   event_name = "resumed";   break;
-    case RUBY_INTERNAL_THREAD_EVENT_SUSPENDED: event_name = "suspended"; break;
+    case RUBY_INTERNAL_THREAD_EVENT_RESUMED:   event_name = "running";   break;
+    case RUBY_INTERNAL_THREAD_EVENT_SUSPENDED: event_name = "waiting";   break;
     case RUBY_INTERNAL_THREAD_EVENT_STARTED:   event_name = "started";   break;
     case RUBY_INTERNAL_THREAD_EVENT_EXITED:    event_name = "exited";    break;
   };


### PR DESCRIPTION
Fix: #2 
As discussed on Twitter.

The `RUBY_INTERNAL_THREAD_EVENT_*` names convey state transition not status. Given that `gvl-tracing` generate areas with a state until the next event, it would be more clear to disaply thread status instead.

I think `running` is best to describe threads that have acquire the GVL and are actually executing.

For `waiting` is the best I could find to describe thread waiting for IO or join. But `sleeping` could do as well.

And finally I think `ready` works to describe threads that could be executed but are waiting on the GVL.

Either way the README should probably describe the signification of each status.

FYI @ko1