### PR TITLE
OSX compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /experiments/
 gems.locked
 *.so
+*.bundle
 example*json


### PR DESCRIPTION
`gettid()` isn't available on OSX. But we can use the Ruby's `thread_native.h` to get an identifier.