### PR TITLE
Fix perfetto output for using in ff profiler

### DIFF
--- a/lib/gvl-tracing.rb
+++ b/lib/gvl-tracing.rb
@@ -61,7 +61,7 @@ module GvlTracing
       threads_name = aggreate_thread_list(list).join(",\n")
       File.open(@path, "a") do |f|
         f.puts(threads_name)
-        f.puts("]")
+        f.puts("]}")
       end
     end
 


### PR DESCRIPTION
* Firefox Profiler requires a "traceEvents" key and that every row has a "name" key (which is not required by the perfetto spec for "E" phases)

* The spec doesn't require those https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit?pli=1 but the firefox profiler code does 
  * https://github.com/firefox-devtools/profiler/blob/358a1c77111edf944d09fbe79012a08832a9cb59/src/profile-logic/import/chrome.js#L232 (traceEvents is how it determines it is perfetto or "chrome")
  * https://github.com/firefox-devtools/profiler/blob/358a1c77111edf944d09fbe79012a08832a9cb59/src/profile-logic/import/chrome.js#L249 (it at least requires "name" to be an empty string, but when empty it does not output properly in firefox profiler)

* WIP - it's not fully functional yet - it also is more a proof of concept right now since the changes i'll have for Ruby 3.3 will probably refactor away from thead locals, so this code will change as well