### PR TITLE
Support for 3.3 and N:M threads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ['3.2', '3.3', head, debug]
+        mn_threads: ["0", "1"]
         exclude:
           - os: windows-latest
             ruby: debug
+          - ruby: "3.2"
+            mn_threads: "1"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -22,4 +25,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: bundle exec rake
+    - name: bundle exec rake
+      run: |
+        ruby -v
+        bundle exec rake
+      env:
+        RUBY_MN_THREADS: ${{ matrix.mn_threads }}

--- a/ext/gvl_tracing_native_extension/extconf.rb
+++ b/ext/gvl_tracing_native_extension/extconf.rb
@@ -36,6 +36,8 @@ have_func("gettid", "unistd.h")
 have_header("pthread.h")
 have_func("pthread_getname_np", "pthread.h")
 have_func("pthread_threadid_np", "pthread.h")
+have_func("rb_internal_thread_specific_get", "ruby/thread.h") # 3.3+
+
 append_cflags("-Werror-implicit-function-declaration")
 append_cflags("-Wunused-parameter")
 append_cflags("-Wold-style-definition")

--- a/ext/gvl_tracing_native_extension/gvl_tracing.c
+++ b/ext/gvl_tracing_native_extension/gvl_tracing.c
@@ -116,6 +116,7 @@ static double started_tracing_at_microseconds = 0;
 static int64_t process_id = 0;
 static VALUE gc_tracepoint = Qnil;
 
+static VALUE tracing_init_local_storage(VALUE, VALUE);
 static VALUE tracing_start(VALUE _self, VALUE output_path);
 static VALUE tracing_stop(VALUE _self);
 static double timestamp_microseconds(void);
@@ -134,6 +135,7 @@ void Init_gvl_tracing_native_extension(void) {
 
   VALUE gvl_tracing_module = rb_define_module("GvlTracing");
 
+  rb_define_singleton_method(gvl_tracing_module, "_init_local_storage", tracing_init_local_storage, 1);
   rb_define_singleton_method(gvl_tracing_module, "_start", tracing_start, 1);
   rb_define_singleton_method(gvl_tracing_module, "_stop", tracing_stop, 0);
   rb_define_singleton_method(gvl_tracing_module, "mark_sleeping", mark_sleeping, 0);
@@ -160,6 +162,11 @@ static inline void render_thread_metadata(thread_local_state *state) {
   fprintf(output_file,
     "  {\"ph\": \"M\", \"pid\": %"PRId64", \"tid\": %"PRIu64", \"name\": \"thread_name\", \"args\": {\"name\": \"%s\"}},\n",
     process_id, thread_id, native_thread_name_buffer);
+}
+
+static VALUE tracing_init_local_storage(UNUSED_ARG VALUE _self, VALUE thread) {
+  GT_LOCAL_STATE(thread, true);
+  return Qtrue;
 }
 
 static VALUE tracing_start(UNUSED_ARG VALUE _self, VALUE output_path) {

--- a/ext/gvl_tracing_native_extension/gvl_tracing.c
+++ b/ext/gvl_tracing_native_extension/gvl_tracing.c
@@ -156,6 +156,10 @@ static inline void render_thread_metadata(thread_local_state *state) {
 
   #ifdef HAVE_RB_INTERNAL_THREAD_SPECIFIC_GET
     uint64_t thread_id = (uint64_t)state->thread;
+    // For JSON, values above only 53 bits are interoperable
+    #if SIZEOF_VALUE > 4
+      thread_id = ((uint32_t)(thread_id >> 32) ^ (uint32_t)(thread_id & 0xFFFFFFFF));
+    #endif
   #else
     uint64_t thread_id = state->thread_id;
   #endif
@@ -272,6 +276,10 @@ static void render_event(thread_local_state *state, const char *event_name) {
 
   #ifdef HAVE_RB_INTERNAL_THREAD_SPECIFIC_GET
     uint64_t thread_id = (uint64_t)state->thread;
+    // Thread IDs are 32-bit
+    #if SIZEOF_VALUE > 4
+      thread_id = ((uint32_t)(thread_id >> 32) ^ (uint32_t)(thread_id & 0xFFFFFFFF));
+    #endif
   #else
     uint64_t thread_id = state->thread_id;
   #endif

--- a/ext/gvl_tracing_native_extension/gvl_tracing.c
+++ b/ext/gvl_tracing_native_extension/gvl_tracing.c
@@ -164,8 +164,13 @@ static inline void render_thread_metadata(thread_local_state *state) {
     process_id, thread_id, native_thread_name_buffer);
 }
 
-static VALUE tracing_init_local_storage(UNUSED_ARG VALUE _self, VALUE thread) {
-  GT_LOCAL_STATE(thread, true);
+static VALUE tracing_init_local_storage(UNUSED_ARG VALUE _self, VALUE threads) {
+  #ifdef HAVE_RB_INTERNAL_THREAD_SPECIFIC_GET // 3.3+
+    for (long i = 0, len = RARRAY_LEN(threads); i < len; i++) {
+        VALUE thread = RARRAY_AREF(threads, i);
+        GT_LOCAL_STATE(thread, true);
+    }
+  #endif
   return Qtrue;
 }
 

--- a/lib/gvl-tracing.rb
+++ b/lib/gvl-tracing.rb
@@ -35,6 +35,9 @@ module GvlTracing
     private :_stop
 
     def start(file)
+      Thread.list.each do |thread|
+        _init_local_storage(thread)
+      end
       _start(file)
       @path = file
 

--- a/lib/gvl-tracing.rb
+++ b/lib/gvl-tracing.rb
@@ -35,10 +35,8 @@ module GvlTracing
     private :_stop
 
     def start(file)
-      Thread.list.each do |thread|
-        _init_local_storage(thread)
-      end
       _start(file)
+      _init_local_storage(Thread.list)
       @path = file
 
       return unless block_given?

--- a/spec/gvl_tracing_spec.rb
+++ b/spec/gvl_tracing_spec.rb
@@ -50,8 +50,6 @@ RSpec.describe GvlTracing do
 
   describe "order of events" do
     it "first and last events are in a consistent order" do
-      pending "Ruby 3.3 support is WIP" unless RUBY_VERSION.start_with?("3.2.")
-
       GvlTracing.start(trace_path) do
         [Thread.new {}, Thread.new {}].each(&:join)
       end


### PR DESCRIPTION
Fix #17 
Paired with @byroot 

This PR adds support for Ruby 3.3 by using the new `rb_internal_thread_specific_get` which allows accessing data specific to a Ruby thread without requiring the GVL to be locked. It also handles N:M threads automatically.

More info here: https://github.com/ruby/ruby/commit/352a885a0f1a4d4576c686301ee71ea887a345e5

In Ruby 3.3, the thread events don't necessarily run from the thread they correspond to, so the thread corresponding to the event is sent in `event_data`, and now `GT_LOCAL_STATE` needs to take the thread too.

To handle GC, the thread specific data is wrapped into a TypedData struct and stored in the Ruby thread as a instance variable. This requires getting the GVL, so we have an `allocate` flag on `GT_LOCAL_STATE` too, which is false when we're not running from the thread and can't allocate. The hook only runs from its corresponding thread for the `RUBY_INTERNAL_THREAD_EVENT_STARTED` and `RUBY_INTERNAL_THREAD_EVENT_RESUMED` events, so we can allocate there.

If the local state hasn't been initialized yet, we just return early. This means we would skipping events from already existing threads that haven't been resumed yet. To avoid this, we initialize all threads when tracing starts. We do this from Ruby, which ensures we have the GVL. We added a spec for that, which passes on main on 3.2, but not on 3.3.

To support N:M threads (and differentiate events from different threads but the same native thread), instead of returning the native thread id, we know return the address of the Ruby thread in `tid` (on Ruby 3.3).